### PR TITLE
workaround for overriding root page in case of cached pages inside Sh…

### DIFF
--- a/Scanbot-Classic-UI-Scan-Not-Resuming/AppShell.xaml.cs
+++ b/Scanbot-Classic-UI-Scan-Not-Resuming/AppShell.xaml.cs
@@ -1,4 +1,6 @@
-﻿namespace Scanbot_Classic_UI_Scan_Not_Resuming
+﻿using System.Reflection;
+
+namespace Scanbot_Classic_UI_Scan_Not_Resuming
 {
     public partial class AppShell : Shell
     {
@@ -7,6 +9,25 @@
             InitializeComponent();
 
             Routing.RegisterRoute(nameof(NextPage), typeof(NextPage));
+            Routing.RegisterRoute(nameof(MainPage), typeof(MainPage));
+        }
+
+        ShellContent _previousShellContent;
+
+        protected override void OnNavigated(ShellNavigatedEventArgs args)
+        {
+            base.OnNavigated(args);
+            if (CurrentItem?.CurrentItem?.CurrentItem is not null &&
+                _previousShellContent is not null)
+            {
+                var property = typeof(ShellContent)
+                    .GetProperty("ContentCache", BindingFlags.Public |
+                                                 BindingFlags.NonPublic | BindingFlags.Instance |
+                                                 BindingFlags.FlattenHierarchy);
+                property.SetValue(_previousShellContent, null);
+            }
+
+            _previousShellContent = CurrentItem?.CurrentItem?.CurrentItem;
         }
     }
 }

--- a/Scanbot-Classic-UI-Scan-Not-Resuming/MainPage.xaml.cs
+++ b/Scanbot-Classic-UI-Scan-Not-Resuming/MainPage.xaml.cs
@@ -29,6 +29,13 @@ namespace Scanbot_Classic_UI_Scan_Not_Resuming
             license.Text = $"License status: Expires in {duration?.TotalSeconds ?? 0} seconds.";
         }
 
+        protected override void OnDisappearing()
+        {
+            base.OnDisappearing();
+            
+            cameraView.Handler?.DisconnectHandler();
+        }
+
         private void CameraView_OnOnBarcodeScanResult(BarcodeResultBundle result)
         {
             Debug.WriteLine("Barcode scanned: " + result.Barcodes[0].Text);

--- a/Scanbot-Classic-UI-Scan-Not-Resuming/Scanbot-Classic-UI-Scan-Not-Resuming.csproj
+++ b/Scanbot-Classic-UI-Scan-Not-Resuming/Scanbot-Classic-UI-Scan-Not-Resuming.csproj
@@ -58,7 +58,7 @@
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
-		<PackageReference Include="ScanbotBarcodeSDK.MAUI" Version="4.2.2-beta.4" />
+		<PackageReference Include="ScanbotBarcodeSDK.MAUI" Version="4.2.2-beta.6" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Seems like, using this kind of routing where the root item needs to be replaced, the current item is cached and the disconnect handler is not automatically called when the page is removed. As a result, a large number of zombie objects are retained. 
We improved disconnectHandler handler but there is still an issue with inside of Shell component that needs to hacked.  

some of the topics about it:
https://github.com/dotnet/maui/issues/7354
https://github.com/dotnet/maui/issues/9300